### PR TITLE
feat: Implement playlist sharing via unique links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import LoginPage from "./pages/LoginPage";
 import EditProfilePage from "./pages/EditProfilePage";
 import LoadingComponent from "./components/LoadingComponent";
 import PlaylistPage from "./pages/PlaylistPage";
+import SharedPlaylistPage from "./pages/SharedPlaylistPage";
 import { useContext, useEffect, useState } from "react";
 import playerContext from "./context/PlayerContext/PlayerContext";
 import GenrePage from "./pages/GenrePage";
@@ -61,6 +62,7 @@ function App() {
                   element={<PlaylistPage />}
                 />
                 <Route path="/genre/:genreName" element={<GenrePage />} />
+                <Route path="/share/user/:userId/playlist/:playlistId" element={<SharedPlaylistPage />} />
                 <Route path="*" element={<Navigate to={"/"} replace />} />
               </Routes>
             </div>

--- a/src/context/PlayerContext/PlayerState.jsx
+++ b/src/context/PlayerContext/PlayerState.jsx
@@ -30,7 +30,7 @@ function PlayerState(props) {
           where("email", "==", auth.currentUser.email)
         ),
         (snapshot) => {
-          const newData = snapshot.docs.map((doc) => ({ ...doc.data() }));
+          const newData = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
           //setUserData(snapshot.docs.map((doc) => ({ ...doc.data() })));
           setUserData(newData);
           console.log("snapshot", newData);

--- a/src/firebase/hooks/getSharedPlaylist.js
+++ b/src/firebase/hooks/getSharedPlaylist.js
@@ -1,0 +1,28 @@
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../credenciales";
+
+export async function getSharedPlaylist(userId, playlistId) {
+  try {
+    const userRef = doc(db, "users", userId);
+    const userSnap = await getDoc(userRef);
+
+    if (userSnap.exists()) {
+      const userData = userSnap.data();
+      const playlists = userData.playlists || [];
+      const playlist = playlists.find((p) => p.id === playlistId);
+
+      if (playlist) {
+        return playlist;
+      } else {
+        console.error("Playlist not found");
+        return null;
+      }
+    } else {
+      console.error("User not found");
+      return null;
+    }
+  } catch (error) {
+    console.error("Error fetching shared playlist:", error);
+    throw error; // Re-throw the error to allow for further handling if needed
+  }
+}

--- a/src/pages/PlaylistPage/PlaylistPage.jsx
+++ b/src/pages/PlaylistPage/PlaylistPage.jsx
@@ -1,50 +1,106 @@
-import { Button, Typography } from "@mui/material";
+import { Button, Typography, IconButton, TextField, Modal, Box, Tooltip } from "@mui/material";
 import React, { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import playerContext from "../../context/PlayerContext/PlayerContext";
+import ShareIcon from '@mui/icons-material/Share';
 import LoadingComponent from "../../components/LoadingComponent";
 import ListSongCard from "../../components/ListSongCard/ListSongCard";
 import { COLORS } from "../../colors/colors";
 import { FaPlay } from "react-icons/fa6";
 
+const modalStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+};
+
 function PlaylistPage() {
   const { userData, playlistIndex, setPlaylistIndex, setPlaylistSongs } =
     useContext(playerContext);
   const { playlistId } = useParams();
+  const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [shareLink, setShareLink] = useState("");
+  const [copiedTooltipOpen, setCopiedTooltipOpen] = useState(false);
 
   let playlistData =
-    userData.length == 0
-      ? []
+    userData.length === 0
+      ? null
       : userData[0].playlists.find((playlist) => playlist.id == playlistId);
 
+  const handleOpenShareModal = () => {
+    if (userData && userData.length > 0 && userData[0].id && playlistData && playlistData.id) {
+      const link = `${window.location.origin}/share/user/${userData[0].id}/playlist/${playlistData.id}`;
+      setShareLink(link);
+      setShareModalOpen(true);
+    } else {
+      console.error("User ID or Playlist ID is missing for sharing.");
+      // Optionally, disable the button or show a message
+    }
+  };
+
+  const handleCloseShareModal = () => {
+    setShareModalOpen(false);
+    setCopiedTooltipOpen(false); // Reset tooltip state
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(shareLink).then(() => {
+      setCopiedTooltipOpen(true);
+      setTimeout(() => setCopiedTooltipOpen(false), 2000); // Hide tooltip after 2s
+    }).catch(err => {
+      console.error('Failed to copy: ', err);
+    });
+  };
+
   const handlePlayPlaylist = () => {
-    // if (playlistSongs !== playlistData.playlistSet) {
-    //   setCurrentSong({});
-    //   setPlaylistSongs(playlistData.playlistSet);
-    // }
-    setPlaylistSongs([...playlistData.playlistSet]);
-    setPlaylistIndex(0);
-    console.log(playlistIndex, "playlistPageButton");
+    if (playlistData && playlistData.playlistSet) {
+      setPlaylistSongs([...playlistData.playlistSet]);
+      setPlaylistIndex(0);
+      console.log(playlistIndex, "playlistPageButton");
+    }
   };
 
   const handlePlaylistIndex = (index) => {
-    setPlaylistIndex(index);
-    setPlaylistSongs(playlistData.playlistSet);
-    console.log(index, "playlistPage");
+    if (playlistData && playlistData.playlistSet) {
+      setPlaylistIndex(index);
+      setPlaylistSongs(playlistData.playlistSet);
+      console.log(index, "playlistPage");
+    }
   };
 
-  if (userData.length === 0) {
+  if (userData.length === 0 || !playlistData) {
+    // Combined loading/not found logic for simplicity, can be separated
     return <LoadingComponent />;
   }
 
+  // Ensure playlistData is defined before trying to access its properties
   if (playlistData == undefined) {
     return <div>NO EXISTE LA PLAYLIST</div>;
   }
+
   return (
     <div>
-      <Typography variant="h3">{playlistData.name}</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', marginBottom: 2 }}>
+        <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
+          {playlistData.name}
+        </Typography>
+        {userData[0]?.id && playlistData?.id && (
+          <Tooltip title="Share Playlist">
+            <IconButton onClick={handleOpenShareModal} sx={{ color: COLORS.textColor }}>
+              <ShareIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
       <Button
-        onClick={() => handlePlayPlaylist()}
+        onClick={handlePlayPlaylist}
+        disabled={!playlistData || !playlistData.playlistSet || playlistData.playlistSet.length === 0}
         sx={{
           backgroundColor: COLORS.highlightBackgroundColor,
           color: COLORS.textColor,
@@ -60,9 +116,60 @@ function PlaylistPage() {
           Reproducir Playlist
         </div>
       </Button>
-      {playlistData.playlistSet.map((song, index) => {
-        return (
-          <div key={song.id} style={{ display: "flex", alignItems: "center" }}>
+      {playlistData.playlistSet && playlistData.playlistSet.length > 0 ? (
+        playlistData.playlistSet.map((song, index) => {
+          return (
+            <div key={song.id || index} style={{ display: "flex", alignItems: "center" }}>
+              <Typography sx={{ marginRight: 2 }} variant="body1" fontWeight={500}>
+                {index + 1}
+              </Typography>
+              <div style={{ width: "100%" }}>
+                <ListSongCard
+                  song={song}
+                  isInPlaylist={true}
+                  playlistId={playlistId}
+                  onClick={() => handlePlaylistIndex(index)}
+                />
+              </div>
+            </div>
+          );
+        })
+      ) : (
+        <Typography>This playlist is empty.</Typography>
+      )}
+
+      <Modal
+        open={shareModalOpen}
+        onClose={handleCloseShareModal}
+        aria-labelledby="share-playlist-modal-title"
+        aria-describedby="share-playlist-modal-description"
+      >
+        <Box sx={modalStyle}>
+          <Typography id="share-playlist-modal-title" variant="h6" component="h2">
+            Share Playlist
+          </Typography>
+          <TextField
+            fullWidth
+            readOnly
+            value={shareLink}
+            sx={{ mt: 2, mb: 2 }}
+            label="Shareable Link"
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <Button onClick={handleCloseShareModal}>Close</Button>
+            <Tooltip title={copiedTooltipOpen ? "Copied!" : "Copy to clipboard"} open={copiedTooltipOpen} placement="top">
+              <Button variant="contained" onClick={handleCopyLink}>
+                Copy Link
+              </Button>
+            </Tooltip>
+          </Box>
+        </Box>
+      </Modal>
+    </div>
+  );
+}
+
+export default PlaylistPage;
             <Typography sx={{ marginRight: 2 }} variant="body" fontWeight={500}>
               {index + 1}
             </Typography>

--- a/src/pages/SharedPlaylistPage/SharedPlaylistPage.jsx
+++ b/src/pages/SharedPlaylistPage/SharedPlaylistPage.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getSharedPlaylist } from "../../firebase/hooks/getSharedPlaylist";
+import LoadingComponent from "../../components/LoadingComponent";
+import ListSongCard from "../../components/ListSongCard/ListSongCard";
+import { Typography } from "@mui/material";
+
+const SharedPlaylistPage = () => {
+  const { userId, playlistId } = useParams();
+  const [playlist, setPlaylist] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchPlaylist = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const sharedPlaylist = await getSharedPlaylist(userId, playlistId);
+        if (sharedPlaylist) {
+          setPlaylist(sharedPlaylist);
+        } else {
+          setError("Playlist not found.");
+        }
+      } catch (err) {
+        setError("Error fetching playlist: " + err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (userId && playlistId) {
+      fetchPlaylist();
+    }
+  }, [userId, playlistId]);
+
+  if (loading) {
+    return <LoadingComponent />;
+  }
+
+  if (error) {
+    return <Typography color="error">{error}</Typography>;
+  }
+
+  if (!playlist) {
+    return <Typography>Playlist not found.</Typography>;
+  }
+
+  return (
+    <div>
+      <Typography variant="h3" gutterBottom>
+        {playlist.name}
+      </Typography>
+      {playlist.playlistSet && playlist.playlistSet.length > 0 ? (
+        playlist.playlistSet.map((song, index) => (
+          <div key={song.id || index} style={{ display: 'flex', alignItems: 'center', marginBottom: '8px' }}>
+            <Typography variant="body1" style={{ marginRight: '16px' }}>
+              {index + 1}.
+            </Typography>
+            <ListSongCard song={song} />
+          </div>
+        ))
+      ) : (
+        <Typography>This playlist has no songs.</Typography>
+      )}
+    </div>
+  );
+};
+
+export default SharedPlaylistPage;

--- a/src/pages/SharedPlaylistPage/index.js
+++ b/src/pages/SharedPlaylistPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './SharedPlaylistPage';


### PR DESCRIPTION
This feature allows you to share your playlists with others using a unique URL.

Key changes include:

- Added a `getSharedPlaylist(userId, playlistId)` Firebase hook to fetch specific playlists.
- Created a new `SharedPlaylistPage.jsx` to display shared playlists. This page is accessible via routes like `/share/user/:userId/playlist/:playlistId`.
- Modified `PlayerState.jsx` and `getUserData.js` to include your Firestore document ID in the `userData` state, necessary for generating share links.
- Added a "Share" button to `PlaylistPage.jsx` which opens a modal displaying the shareable link and allows copying it to the clipboard.
- Updated routing in `App.jsx` to include the new shared playlist page.

The implementation allows viewing shared playlists for both logged-out users and other logged-in users. Error handling for invalid user or playlist IDs in the URL is included on the `SharedPlaylistPage`.